### PR TITLE
[HotFix] #27 - .title() 모디파이어 제거

### DIFF
--- a/MC3-BeyondThe3F/MC3-BeyondThe3F/View/BucketView.swift
+++ b/MC3-BeyondThe3F/MC3-BeyondThe3F/View/BucketView.swift
@@ -10,7 +10,6 @@ import SwiftUI
 struct BucketView: View {
     var body: some View {
         Text(/*@START_MENU_TOKEN@*/"Hello, World!"/*@END_MENU_TOKEN@*/)
-            .title(color: .gray100)
     }
 }
 


### PR DESCRIPTION
# PR 요약

작업한 브랜치
- feature/ #27 

# 작업한 내용
- BucketView에 있던 사용하지 않는 .title() 모디파이어가 있어서 에러를 지속적으로 발생시켜서 Conflict 방지를 위해 제거


# 참고 사항
- 

# 관련 이슈
- resolved : #27 
