### PR TITLE
MainView DataModel 추가 및 dummy Data 추가

### DIFF
--- a/MC3-BeyondThe3F/MC3-BeyondThe3F.xcodeproj/project.pbxproj
+++ b/MC3-BeyondThe3F/MC3-BeyondThe3F.xcodeproj/project.pbxproj
@@ -12,6 +12,10 @@
 		74EF8C862A67D338006B8DBC /* PinLocationComponentView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 74EF8C852A67D338006B8DBC /* PinLocationComponentView.swift */; };
 		74EF8C9C2A6832BF006B8DBC /* MusicSearchView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 74EF8C9B2A6832BF006B8DBC /* MusicSearchView.swift */; };
 		74EF8CA22A68B7CC006B8DBC /* ContentsLargeComponentView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 74EF8CA12A68B7CC006B8DBC /* ContentsLargeComponentView.swift */; };
+		76104ABC2A6D7991000B8E65 /* MainDataModel.swift in Sources */ = {isa = PBXBuildFile; fileRef = 76104ABB2A6D7991000B8E65 /* MainDataModel.swift */; };
+		76104ABE2A6D7EF7000B8E65 /* dummy.swift in Sources */ = {isa = PBXBuildFile; fileRef = 76104ABD2A6D7EF7000B8E65 /* dummy.swift */; };
+		76104AC32A6D9B1C000B8E65 /* LocationManager.swift in Sources */ = {isa = PBXBuildFile; fileRef = 76104AC22A6D9B1C000B8E65 /* LocationManager.swift */; };
+		76104AC52A6DF978000B8E65 /* MainVO.swift in Sources */ = {isa = PBXBuildFile; fileRef = 76104AC42A6DF978000B8E65 /* MainVO.swift */; };
 		764936AF2A6A169B001C0C54 /* MusicDataModel.swift in Sources */ = {isa = PBXBuildFile; fileRef = 764936AE2A6A169B001C0C54 /* MusicDataModel.swift */; };
 		951691832A6629670070D47C /* MC3_BeyondThe3FApp.swift in Sources */ = {isa = PBXBuildFile; fileRef = 951691822A6629670070D47C /* MC3_BeyondThe3FApp.swift */; };
 		951691852A6629670070D47C /* ContentView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 951691842A6629670070D47C /* ContentView.swift */; };
@@ -49,6 +53,10 @@
 		74EF8C852A67D338006B8DBC /* PinLocationComponentView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = PinLocationComponentView.swift; sourceTree = "<group>"; };
 		74EF8C9B2A6832BF006B8DBC /* MusicSearchView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = MusicSearchView.swift; sourceTree = "<group>"; };
 		74EF8CA12A68B7CC006B8DBC /* ContentsLargeComponentView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ContentsLargeComponentView.swift; sourceTree = "<group>"; };
+		76104ABB2A6D7991000B8E65 /* MainDataModel.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = MainDataModel.swift; sourceTree = "<group>"; };
+		76104ABD2A6D7EF7000B8E65 /* dummy.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = dummy.swift; sourceTree = "<group>"; };
+		76104AC22A6D9B1C000B8E65 /* LocationManager.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = LocationManager.swift; sourceTree = "<group>"; };
+		76104AC42A6DF978000B8E65 /* MainVO.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = MainVO.swift; sourceTree = "<group>"; };
 		764936AE2A6A169B001C0C54 /* MusicDataModel.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = MusicDataModel.swift; sourceTree = "<group>"; };
 		9516917F2A6629670070D47C /* MC3-BeyondThe3F.app */ = {isa = PBXFileReference; explicitFileType = wrapper.application; includeInIndex = 0; path = "MC3-BeyondThe3F.app"; sourceTree = BUILT_PRODUCTS_DIR; };
 		951691822A6629670070D47C /* MC3_BeyondThe3FApp.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = MC3_BeyondThe3FApp.swift; sourceTree = "<group>"; };
@@ -193,6 +201,10 @@
 				953BD74A2A68DE6C0047C21C /* MusicAnnotation.swift */,
 				953BD74B2A68DE6C0047C21C /* MusicItemVO.swift */,
 				764936AE2A6A169B001C0C54 /* MusicDataModel.swift */,
+				76104ABB2A6D7991000B8E65 /* MainDataModel.swift */,
+				76104ABD2A6D7EF7000B8E65 /* dummy.swift */,
+				76104AC22A6D9B1C000B8E65 /* LocationManager.swift */,
+				76104AC42A6DF978000B8E65 /* MainVO.swift */,
 			);
 			path = Model;
 			sourceTree = "<group>";
@@ -331,8 +343,10 @@
 				9516918C2A6629680070D47C /* Persistence.swift in Sources */,
 				74EF8C742A67C198006B8DBC /* ButtonPlayComponentView.swift in Sources */,
 				95D6CE142A6D084E0053AE8E /* LocationHelper.swift in Sources */,
+				76104ABE2A6D7EF7000B8E65 /* dummy.swift in Sources */,
 				953BD7602A6A6D0A0047C21C /* ClusteringAnnotationView.swift in Sources */,
 				74EF8C862A67D338006B8DBC /* PinLocationComponentView.swift in Sources */,
+				76104AC32A6D9B1C000B8E65 /* LocationManager.swift in Sources */,
 				953BD7512A6919370047C21C /* SmallButtonComponentView.swift in Sources */,
 				9516918F2A6629680070D47C /* MC3_BeyondThe3F.xcdatamodeld in Sources */,
 				74EF8C9C2A6832BF006B8DBC /* MusicSearchView.swift in Sources */,
@@ -347,7 +361,9 @@
 				953BD7622A6A6D5D0047C21C /* MusicAnnotationView.swift in Sources */,
 				951691832A6629670070D47C /* MC3_BeyondThe3FApp.swift in Sources */,
 				74EF8CA22A68B7CC006B8DBC /* ContentsLargeComponentView.swift in Sources */,
+				76104AC52A6DF978000B8E65 /* MainVO.swift in Sources */,
 				951691AC2A663E7C0070D47C /* TypoModifier.swift in Sources */,
+				76104ABC2A6D7991000B8E65 /* MainDataModel.swift in Sources */,
 				951691A22A6639320070D47C /* MainTabView.swift in Sources */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;

--- a/MC3-BeyondThe3F/MC3-BeyondThe3F/Model/LocationManager.swift
+++ b/MC3-BeyondThe3F/MC3-BeyondThe3F/Model/LocationManager.swift
@@ -1,0 +1,25 @@
+//
+//  LocationManager.swift
+//  MC3-BeyondThe3F
+//
+//  Created by jaesik pyeon on 2023/07/24.
+//
+
+import Foundation
+
+class LocationManager{
+    
+    static let shared = LocationManager()
+    private init(){}
+    
+    let loc = (latitude:37.5,longitude:127.5)
+    
+    func getDistance(latitude:Double,longitude:Double)->Double{
+        let loc = (latitude:37.5,longitude:127.5)
+
+        let x = (latitude - loc.latitude)*100000.0*0.884
+        let y = (longitude - loc.longitude)*100000.0*1.110
+        
+        return pow((x*x)+(y*y),0.5)
+    }
+}

--- a/MC3-BeyondThe3F/MC3-BeyondThe3F/Model/MainDataModel.swift
+++ b/MC3-BeyondThe3F/MC3-BeyondThe3F/Model/MainDataModel.swift
@@ -1,0 +1,45 @@
+//
+//  MainDataModel.swift
+//  MC3-BeyondThe3F
+//
+//  Created by jaesik pyeon on 2023/07/24.
+//
+
+import Foundation
+
+
+class MainDataModel{
+    static let shared = MainDataModel()
+    private init(){}
+    let loc = (lat:37.5,long:127.5)
+
+    let musicItemDataModel = MusicItemDataModel.shared
+    let locationManager = LocationManager.shared
+    
+    var getData:[MainVO]{
+        var dic:[String:[MusicItem]] = [:]
+        musicItemDataModel.musicList.forEach {
+            if var arr = dic[$0.locationInfo ?? ""]{
+                arr.append($0)
+                dic[$0.locationInfo ?? ""] = arr
+            }else{
+                dic[$0.locationInfo ?? ""] = [$0]
+            }
+        }
+        var tempArr:[[MusicItem]] = []
+        for (_,value) in dic{
+            tempArr.append(value)
+        }
+        dic.forEach {
+            tempArr.append($0.value)
+        }
+        
+        tempArr.sort{
+            let left = locationManager.getDistance(latitude: $0[0].latitude, longitude: $0[0].longitude)
+            let right = locationManager.getDistance(latitude: $1[0].latitude, longitude: $1[0].longitude)
+            return left < right
+        }
+
+        return tempArr.map{ MainVO(locationInfo: $0[0].locationInfo ?? "", musicList: $0) }
+    }
+}

--- a/MC3-BeyondThe3F/MC3-BeyondThe3F/Model/MainVO.swift
+++ b/MC3-BeyondThe3F/MC3-BeyondThe3F/Model/MainVO.swift
@@ -1,0 +1,14 @@
+//
+//  MainVO.swift
+//  MC3-BeyondThe3F
+//
+//  Created by jaesik pyeon on 2023/07/24.
+//
+
+import Foundation
+
+struct MainVO{
+    let locationInfo:String
+    var musicList:[MusicItem]
+    
+}

--- a/MC3-BeyondThe3F/MC3-BeyondThe3F/Model/MusicDataModel.swift
+++ b/MC3-BeyondThe3F/MC3-BeyondThe3F/Model/MusicDataModel.swift
@@ -8,9 +8,14 @@
 import Foundation
 import CoreData
 
+protocol MusicItemDataModelDelegate:AnyObject{
+    func musicItemDataModel()->Void
+}
 class MusicItemDataModel {
     static let shared = MusicItemDataModel()
     private init() {}
+    
+    weak var delegate:MusicItemDataModelDelegate?
     
     var persistentContainer = PersistenceController.shared.container
     
@@ -27,6 +32,7 @@ class MusicItemDataModel {
     func saveMusicItem(musicItemVO:MusicItemVO){
 
         let newItem = MusicItem(context: persistentContainer.viewContext)
+        
         newItem.musicId = musicItemVO.musicId
         newItem.desc = musicItemVO.desc
         newItem.latitude = musicItemVO.latitude
@@ -43,5 +49,16 @@ class MusicItemDataModel {
             fatalError("Unresolved error \(nsError), \(nsError.userInfo)")
         }
     }
-    
+    var mainMusic:[String:[MusicItemVO]]{
+        var items:[String:[MusicItemVO]] = [:]
+        for music in musicList {
+            if var item = items[music.locationInfo ?? ""]{
+                item.append(MusicItemVO(musicId: music.musicId ?? "", latitude: music.latitude, longitude: music.longitude, playedCount: Int(music.playedCount), songName: "", artistName: "", generatedDate: Date()))
+                items[music.locationInfo ?? ""] = item
+            }else{
+                items[music.locationInfo ?? ""] = [MusicItemVO(musicId: music.musicId ?? "", latitude: music.latitude, longitude: music.longitude, playedCount: Int(music.playedCount), songName: "", artistName: "", generatedDate: Date())]
+            }
+        }
+        return items
+    }
 }

--- a/MC3-BeyondThe3F/MC3-BeyondThe3F/Model/MusicDataModel.swift
+++ b/MC3-BeyondThe3F/MC3-BeyondThe3F/Model/MusicDataModel.swift
@@ -43,4 +43,5 @@ class MusicItemDataModel {
             fatalError("Unresolved error \(nsError), \(nsError.userInfo)")
         }
     }
+    
 }

--- a/MC3-BeyondThe3F/MC3-BeyondThe3F/Model/MusicItemVO.swift
+++ b/MC3-BeyondThe3F/MC3-BeyondThe3F/Model/MusicItemVO.swift
@@ -18,7 +18,7 @@ struct MusicItemVO: Identifiable, Hashable {
     var artistName: String
     var generatedDate: Date
     var savedImage: String?
-    var locationInfo: String?
+    var locationInfo: String = ""
     var desc: String?
     var coordinate: CLLocationCoordinate2D {
         CLLocationCoordinate2D(

--- a/MC3-BeyondThe3F/MC3-BeyondThe3F/Model/dummy.swift
+++ b/MC3-BeyondThe3F/MC3-BeyondThe3F/Model/dummy.swift
@@ -1,0 +1,33 @@
+//
+//  dummy.swift
+//  MC3-BeyondThe3F
+//
+//  Created by jaesik pyeon on 2023/07/24.
+//
+
+import Foundation
+func insertDummy(){
+    
+    var musicItemDataModel = MusicItemDataModel.shared
+    guard musicItemDataModel.musicList.count == 0 else{ return }
+    
+    for i in 1...10{
+        musicItemDataModel.saveMusicItem(musicItemVO: MusicItemVO(musicId: "sampleMusicID\(i)", latitude: 37.5, longitude: 127.5, playedCount: i, songName: "sampleSongName\(i)", artistName: "artist-\(i)", generatedDate: Date(), savedImage: nil, locationInfo: "포항시", desc: nil))
+    }
+    for i in 1...12{
+        musicItemDataModel.saveMusicItem(musicItemVO: MusicItemVO(musicId: "sampleMusicID\(i)", latitude: 38.5, longitude: 127.5, playedCount: i, songName: "sampleSongName\(i)", artistName: "artist-\(i)", generatedDate: Date(), savedImage: nil, locationInfo: "경주시", desc: nil))
+    }
+    for i in 1...13{
+        musicItemDataModel.saveMusicItem(musicItemVO: MusicItemVO(musicId: "sampleMusicID\(i)", latitude: 39.5, longitude: 127.5, playedCount: i, songName: "sampleSongName\(i)", artistName: "artist-\(i)", generatedDate: Date(), savedImage: nil, locationInfo: "울산시", desc: nil))
+    }
+    for i in 1...14{
+        musicItemDataModel.saveMusicItem(musicItemVO: MusicItemVO(musicId: "sampleMusicID\(i)", latitude: 40.5, longitude: 127.5, playedCount: i, songName: "sampleSongName\(i)", artistName: "artist-\(i)", generatedDate: Date(), savedImage: nil, locationInfo: "대구시", desc: nil))
+    }
+    for i in 1...15{
+        musicItemDataModel.saveMusicItem(musicItemVO: MusicItemVO(musicId: "sampleMusicID\(i)", latitude: 41.5, longitude: 127.5, playedCount: i, songName: "sampleSongName\(i)", artistName: "artist-\(i)", generatedDate: Date(), savedImage: nil, locationInfo: "부산시", desc: nil))
+    }
+    for i in 1...16{
+        musicItemDataModel.saveMusicItem(musicItemVO: MusicItemVO(musicId: "sampleMusicID\(i)", latitude: 42.5, longitude: 127.5, playedCount: i, songName: "sampleSongName\(i)", artistName: "artist-\(i)", generatedDate: Date(), savedImage: nil, locationInfo: "양산시", desc: nil))
+    }
+}
+

--- a/MC3-BeyondThe3F/MC3-BeyondThe3F/View/MainTabView.swift
+++ b/MC3-BeyondThe3F/MC3-BeyondThe3F/View/MainTabView.swift
@@ -20,6 +20,12 @@ struct MainTabView: View {
                     Image(systemName: "map.fill")
                     Text("지도")
                 }
+        }.onAppear{
+            insertDummy()
+            
+            
+            let mainDataModel = MainDataModel.shared
+            mainDataModel.getData
         }
     }
 }


### PR DESCRIPTION
# PR 요약

작업한 브랜치
- feature/ #46

# 작업한 내용
- MainView DataModel 추가 및 dummy Data 추가


# 참고 사항
- https://www.notion.so/logic-kit/DataModel-DataManager-23ac257d7e6e428ca21415abc576679b

# 관련 이슈
- resolved : #이슈번호
