### PR TITLE
MainDataModel 에서 같은 지명의 배열이 중복되던 현상을 해결함.

### DIFF
--- a/MC3-BeyondThe3F/MC3-BeyondThe3F/Model/MainDataModel.swift
+++ b/MC3-BeyondThe3F/MC3-BeyondThe3F/Model/MainDataModel.swift
@@ -27,13 +27,9 @@ class MainDataModel{
             }
         }
         var tempArr:[[MusicItem]] = []
-        for (_,value) in dic{
-            tempArr.append(value)
-        }
         dic.forEach {
             tempArr.append($0.value)
         }
-        
         tempArr.sort{
             let left = locationManager.getDistance(latitude: $0[0].latitude, longitude: $0[0].longitude)
             let right = locationManager.getDistance(latitude: $1[0].latitude, longitude: $1[0].longitude)

--- a/MC3-BeyondThe3F/MC3-BeyondThe3F/View/MainTabView.swift
+++ b/MC3-BeyondThe3F/MC3-BeyondThe3F/View/MainTabView.swift
@@ -25,6 +25,7 @@ struct MainTabView: View {
             Task{
                 await AuthManger.requestMusicAuth()
             }
+            print(MainDataModel.shared.getData)
         }
     }
 }


### PR DESCRIPTION
# PR 요약

작업한 브랜치
- feature/ #80

# 작업한 내용
-  지명의 배열이 중복되던 현상을 해결함. ex. 포항시가 두 번 나오는 것을 해결.


# 참고 사항
-

# 관련 이슈
- resolved : #80
