### PR TITLE
[Design] SearchComponentView 디자인 수정안 반영

### DIFF
--- a/MC3-BeyondThe3F/MC3-BeyondThe3F/View/BucketView.swift
+++ b/MC3-BeyondThe3F/MC3-BeyondThe3F/View/BucketView.swift
@@ -10,6 +10,7 @@ import SwiftUI
 struct BucketView: View {
     var body: some View {
         Text("Hello, World!")
+        MusicSearchCompomponentPreview()
     }
 }
 

--- a/MC3-BeyondThe3F/MC3-BeyondThe3F/View/BucketView.swift
+++ b/MC3-BeyondThe3F/MC3-BeyondThe3F/View/BucketView.swift
@@ -10,7 +10,6 @@ import SwiftUI
 struct BucketView: View {
     var body: some View {
         Text("Hello, World!")
-        MusicSearchCompomponentPreview()
     }
 }
 

--- a/MC3-BeyondThe3F/MC3-BeyondThe3F/View/Components/MusicSearchComponentView.swift
+++ b/MC3-BeyondThe3F/MC3-BeyondThe3F/View/Components/MusicSearchComponentView.swift
@@ -16,22 +16,28 @@ struct MusicSearchComponentView: View {
     var body: some View {
         HStack(spacing: 0){
             HStack {
-                SFImageComponentView(
-                    symbolName: onSearching ? .chevronBack : .magnifyingGlass,
-                    color: .white,
-                    width: 18,
-                    height: 18
-                )
+                Button {
+                    showSearchView = false
+                    searchTerm = ""
+                } label: {
+                    SFImageComponentView(
+                        symbolName: showSearchView ? .chevronBack : .magnifyingGlass,
+                        color: .white,
+                        width: 18,
+                        height: 18
+                    )
+                }
+
                 Spacer()
                     .frame(width: 20)
                 TextField("\(onSearching ? "음악을 검색해보세요":"음악을 추가해보세요")", text: $searchTerm)
                     .focused($onSearching)
                     .onChange(of: onSearching) { searchingState in
-                        
+                        showSearchView = searchingState
                     }
                     
                 Spacer()
-                if onSearching {
+                if showSearchView {
                     Button {
                         searchTerm = ""
                     } label: {

--- a/MC3-BeyondThe3F/MC3-BeyondThe3F/View/Components/MusicSearchComponentView.swift
+++ b/MC3-BeyondThe3F/MC3-BeyondThe3F/View/Components/MusicSearchComponentView.swift
@@ -19,6 +19,7 @@ struct MusicSearchComponentView: View {
                 Button {
                     showSearchView = false
                     searchTerm = ""
+                    onSearching = false
                 } label: {
                     SFImageComponentView(
                         symbolName: showSearchView ? .chevronBack : .magnifyingGlass,
@@ -44,8 +45,8 @@ struct MusicSearchComponentView: View {
                         SFImageComponentView(
                             symbolName: .cancel,
                             color: .gray500,
-                            width: 18,
-                            height: 18)
+                            width: 16,
+                            height: 16)
                     }
 
                 }

--- a/MC3-BeyondThe3F/MC3-BeyondThe3F/View/Components/MusicSearchComponentView.swift
+++ b/MC3-BeyondThe3F/MC3-BeyondThe3F/View/Components/MusicSearchComponentView.swift
@@ -8,27 +8,42 @@
 import SwiftUI
 
 struct MusicSearchComponentView: View {
-    @State private var textInput: String = ""
-    @State private var onSearching = false
+    @Binding var searchTerm: String
+    @Binding var showSearchView: Bool
+    @FocusState private var onSearching : Bool
+    
     
     var body: some View {
-        HStack{
+        HStack(spacing: 0){
             HStack {
                 SFImageComponentView(
                     symbolName: onSearching ? .chevronBack : .magnifyingGlass,
-                    color: .white)
+                    color: .white,
+                    width: 18,
+                    height: 18
+                )
                 Spacer()
                     .frame(width: 20)
-                TextField("음악을 검색해보세요", text: $textInput)
-                    .onTapGesture {
-                        onSearching.toggle()
+                TextField("\(onSearching ? "음악을 검색해보세요":"음악을 추가해보세요")", text: $searchTerm)
+                    .focused($onSearching)
+                    .onChange(of: onSearching) { searchingState in
+                        
                     }
                     
-                    
                 Spacer()
-                SFImageComponentView(symbolName: .mic, color: .white)
+                if onSearching {
+                    Button {
+                        searchTerm = ""
+                    } label: {
+                        SFImageComponentView(
+                            symbolName: .cancel,
+                            color: .gray500,
+                            width: 18,
+                            height: 18)
+                    }
+
+                }
             }
-            .padding()
             .foregroundColor(.white)
             .padding()
             .frame(maxWidth: 350)
@@ -40,14 +55,29 @@ struct MusicSearchComponentView: View {
             
             Spacer()
             
-            SFImageComponentView(symbolName: .gearShape, color: .white)
+            // TODO: Navigate to ShazamView
+            Image(systemName: "shazam.logo.fill")
+                .resizable()
+                .scaledToFit()
+                .frame(width: CGFloat(29), height: CGFloat(29))
+                .foregroundColor(Color.custom(.gray200))
         }
     }
 }
 
+struct MusicSearchCompomponentPreview: View {
+    @State private var searchTerm = ""
+    @State private var showSearchView = false
+    var body: some View {
+        MusicSearchComponentView(
+            searchTerm: $searchTerm,
+            showSearchView: $showSearchView
+        )
+    }
+}
 
 struct MusicSearchComponentView_Previews: PreviewProvider {
     static var previews: some View {
-        MusicSearchComponentView()
+        MusicSearchCompomponentPreview()
     }
 }


### PR DESCRIPTION
# PR 요약

작업한 브랜치
- feature/ #93 

# 작업한 내용
- SearchComponentView mic SFSymbol을 shazam으로 변경
- 전체 삭제 기능 구현
- 뒤로 가기 기능 구현

# 참고 사항
- 추후 SFSymbol에 shazam 추가 필요
- 추후 shazamView navigation 구현 필요

# 구현 내용
![Jul-27-2023 19-44-50](https://github.com/DeveloperAcademy-POSTECH/MC3-Team11-BeyondThe3F/assets/105622985/788cfe8d-bb22-45ac-a952-5105eb26b7a8)

# 관련 이슈
- resolved : #93 
