### PR TITLE
[Feat] #113 - MusicPlayerComponentView 디테일 수정

### DIFF
--- a/MC3-BeyondThe3F/MC3-BeyondThe3F/View/Components/MusicPlayerComponentView.swift
+++ b/MC3-BeyondThe3F/MC3-BeyondThe3F/View/Components/MusicPlayerComponentView.swift
@@ -6,41 +6,83 @@
 //
 
 import SwiftUI
+import MusicKit
 
 struct MusicPlayerComponentView: View {
+    
+    @ObservedObject private var musicPlayer = MusicPlayer.shared
+    @State private var isPlaying = false
+    @State private var showMusicPlayListView = false
+    
+    
     var body: some View {
-        HStack{
-            Spacer()
-                .frame(width: 16)
-            Rectangle()
+        HStack {
+            Image("musicPlayImageEmpty")
+                .resizable()
+                .aspectRatio(contentMode: .fill)
                 .frame(width: 60, height: 60)
                 .cornerRadius(8)
+            
             Spacer()
                 .frame(width: 16)
-            VStack(alignment:.leading){
-                Text("Title")
-                    .body1(color: .white)
-                    .padding(.bottom, 8)
-                Text("subtitle1")
-                    .body2(color: .gray500)
+            
+            VStack(alignment: .leading) {
+                if let currentMusicItem = musicPlayer.currentMusicItem {
+                    Text("\(currentMusicItem.songName ?? "")")
+                        .body1(color: .white)
+                        .truncationMode(.tail)
+                    Spacer()
+                        .frame(height: 6)
+                    Text("\(currentMusicItem.artistName ?? "")")
+                        .body2(color: .gray500)
+                        .truncationMode(.tail)
+                } else {
+                    Text("재생 중이 아님")
+                        .body1(color: .white)
+                        .truncationMode(.tail)
+                }
             }
+            .frame(maxWidth: .infinity, alignment: .leading)
+            .frame(height: 48)
+            
             Spacer()
-            HStack(spacing: 20) {
-                SFImageComponentView(symbolName: .play, color: .white, width: 20)
-                SFImageComponentView(symbolName: .forward, color: .white, width: 35)
-                SFImageComponentView(symbolName: .list, color: .white)
+                .frame(width: 16)
+            
+            HStack(spacing: 24) {
+                Button {
+                    musicPlayer.playButtonTapped()
+                    isPlaying.toggle()
+                } label: {
+                    SFImageComponentView(symbolName: isPlaying ? .play : .pause, color: .white, width: 20)
+                }
+                
+                Button {
+                    musicPlayer.nextButtonTapped()
+                } label: {
+                    SFImageComponentView(symbolName: .forward, color: .white, width: 32)
+                }
+                .disabled(musicPlayer.isLast)
+                
+                Button {
+                    showMusicPlayListView = true
+                } label: {
+                    SFImageComponentView(symbolName: .list, color: .white)
+                }
             }
-            Spacer()
-                .frame(width: 10)
         }
+        .padding(.horizontal, 20)
         .foregroundColor(.white)
         .frame(width: 390, height: 88)
         .background(Color.custom(.secondaryDark))
+        .sheet(isPresented: $showMusicPlayListView) {
+            MusicPlayView()
+                .presentationDragIndicator(.visible)
+        }
     }
 }
 
-struct MusicPlayerComponentView_Previews: PreviewProvider {
-    static var previews: some View {
-        MusicPlayerComponentView()
-    }
-}
+//struct MusicPlayerComponentView_Previews: PreviewProvider {
+//    static var previews: some View {
+//        MusicPlayerComponentView()
+//    }
+//}


### PR DESCRIPTION
# PR 요약

작업한 브랜치
- feature/ #113 

# 작업한 내용
- 노래제목과 아티스트이름 사이 padding 값 수정
- 재생/뒤로 스킵/현재 재생 목록 아이콘 버튼 사이 padding 값 수정
- 재생/뒤로 스킵 아이콘 버튼 기능 구현
- 재생 중인 노래가 없을 때, ‘재생 중이 아님’ 뷰 제공


# 참고 사항
-

# 관련 이슈
- resolved : #113 
