### PR TITLE
[Feat] #128 - MusicPlayView 디테일 작업 (2차)

### DIFF
--- a/MC3-BeyondThe3F/MC3-BeyondThe3F/View/Components/MusicPlayerComponentView.swift
+++ b/MC3-BeyondThe3F/MC3-BeyondThe3F/View/Components/MusicPlayerComponentView.swift
@@ -17,11 +17,27 @@ struct MusicPlayerComponentView: View {
     
     var body: some View {
         HStack {
-            Image("musicPlayImageEmpty")
-                .resizable()
-                .aspectRatio(contentMode: .fill)
-                .frame(width: 60, height: 60)
-                .cornerRadius(8)
+            if let url = URL(string: musicPlayer.currentMusicItem?.savedImage ?? "") {
+                AsyncImage(url: url) { image in
+                    image
+                        .resizable()
+                        .aspectRatio(contentMode: .fill)
+                        .frame(width: 60, height: 60)
+                        .cornerRadius(8)
+                } placeholder: {
+                    Image("musicPlayImageEmpty")
+                        .resizable()
+                        .aspectRatio(contentMode: .fill)
+                        .frame(width: 60, height: 60)
+                        .cornerRadius(8)
+                }
+            } else {
+                Image("musicPlayImageEmpty")
+                    .resizable()
+                    .aspectRatio(contentMode: .fill)
+                    .frame(width: 60, height: 60)
+                    .cornerRadius(8)
+            }
             
             Spacer()
                 .frame(width: 16)
@@ -77,12 +93,8 @@ struct MusicPlayerComponentView: View {
         .sheet(isPresented: $showMusicPlayListView) {
             MusicPlayView()
                 .presentationDragIndicator(.visible)
+            
         }
     }
 }
 
-//struct MusicPlayerComponentView_Previews: PreviewProvider {
-//    static var previews: some View {
-//        MusicPlayerComponentView()
-//    }
-//}


### PR DESCRIPTION
# PR 요약

작업한 브랜치
- feature/ #128 

# 작업한 내용
- 현재 재생 목록에 없다면 ‘현재 재생 목록이 없습니다.’ 뷰 제공
- 재생 중인 노래가 없을때 노래 제목, 아티스트 이름 어떻게 제공할지 고민하기
- 재생 중인 노래가 없을때 이미지 처리
- 재생 중일 때 이미지 돌아가도록 애니메이션


# 참고 사항
-

# 관련 이슈
- resolved : #128 
