### PR TITLE
[Fix] #146 - MusicPlayView와 MusicPlayerComponentView 디테일 수정 (1차)

### DIFF
--- a/MC3-BeyondThe3F/MC3-BeyondThe3F/View/Components/MusicPlayerComponentView.swift
+++ b/MC3-BeyondThe3F/MC3-BeyondThe3F/View/Components/MusicPlayerComponentView.swift
@@ -41,7 +41,7 @@ struct MusicPlayerComponentView: View {
             Spacer()
                 .frame(width: 16)
             
-            VStack {
+            VStack(alignment: .leading) {
                 if let currentMusicItem = musicPlayer.currentMusicItem {
                     Text("\(currentMusicItem.songName ?? "")")
                         .body1(color: .white)

--- a/MC3-BeyondThe3F/MC3-BeyondThe3F/View/Components/MusicPlayerComponentView.swift
+++ b/MC3-BeyondThe3F/MC3-BeyondThe3F/View/Components/MusicPlayerComponentView.swift
@@ -91,7 +91,7 @@ struct MusicPlayerComponentView: View {
         .frame(width: 390, height: 88)
         .background(Color.custom(.secondaryDark))
         .sheet(isPresented: $showMusicPlayListView) {
-            MusicPlayView()
+            MusicPlayView(showCurrentPlayList: true)
                 .presentationDragIndicator(.visible)
             
         }

--- a/MC3-BeyondThe3F/MC3-BeyondThe3F/View/MusicPlayView.swift
+++ b/MC3-BeyondThe3F/MC3-BeyondThe3F/View/MusicPlayView.swift
@@ -122,7 +122,7 @@ struct CurrentPlayListView: View {
                         .body1(color: .gray500)
                         .padding()
                 } else {
-                    ForEach(musicPlayer.playlist) { musicItem in
+                    ForEach(0 ..< musicPlayer.playlist.count, id: \.self) { index in
                         Button {
 //                            musicPlayer.playSong(musicItem)     // 탭하면 해당 노래를 재생
                         } label: {
@@ -147,19 +147,19 @@ struct CurrentPlayListView: View {
                                 }
                                 Spacer()
                                     .frame(width: 16)
-                                VStack(alignment: .leading){
-                                    Text("\(musicItem.songName ?? "")")
+                                VStack(alignment: .leading) {
+                                    Text("\(musicPlayer.playlist[index].songName ?? "")")
                                         .body1(color: .white)
                                         .truncationMode(.tail)
                                         .lineLimit(1)
                                     Spacer()
                                         .frame(height: 6)
-                                    Text("\(musicItem.artistName ?? "")")
+                                    Text("\(musicPlayer.playlist[index].artistName ?? "")")
                                         .body2(color: .gray500)
                                         .truncationMode(.tail)
                                         .lineLimit(1)
                                 }
-                                .frame(maxWidth: .infinity)
+                                .frame(maxWidth: .infinity, alignment: .leading)
                                 Spacer()
                                 Button {
                                     
@@ -171,7 +171,7 @@ struct CurrentPlayListView: View {
                             .frame(maxWidth: 390)
                             .frame(height: 88)
                             .padding(.horizontal, 20)
-                            .background(Color.custom(musicItem == musicPlayer.currentMusicItem ? .secondaryDark : .background))
+                            .background(Color.custom(musicPlayer.playlist[index] == musicPlayer.currentMusicItem ? .secondaryDark : .background))
                             .task {
                                 if let musicId = musicPlayer.currentMusicItem?.musicId{
                                     imageUrl = await MusicItemDataModel.shared.getURL(musicId)
@@ -202,7 +202,7 @@ struct ControlPanelView: View {
             
             VStack {
                 HStack {
-                    VStack {
+                    VStack(alignment: .leading) {
                         if let currentMusicItem = musicPlayer.currentMusicItem {
                             Text("\(currentMusicItem.songName ?? "")")
                                 .headline(color: .white)
@@ -233,7 +233,9 @@ struct ControlPanelView: View {
                         SFImageComponentView(symbolName: .list, color: .white, width: 28, height: 28)
                     }
                 }
-                Spacer().frame(height: 34)
+                Spacer()
+                    .frame(height: 32)
+                
                 ControlButtonsView(progressRate: $progressRate)
             }
             .padding(.horizontal, 20)
@@ -295,12 +297,11 @@ struct ControlButtonsView: View {
                     .caption(color: .white)
             }
             
-            Spacer().frame(height: 36)
+            Spacer().frame(height: 32)
             
             HStack {
                 Button {
                     musicPlayer.previousButtonTapped()
-                    musicPlayer.playlist = MainDataModel.shared.getData[0].musicList
                 } label: {
                     SFImageComponentView(symbolName: .backward, color: .white, width: 45, height: 45)
                 }

--- a/MC3-BeyondThe3F/MC3-BeyondThe3F/View/MusicPlayView.swift
+++ b/MC3-BeyondThe3F/MC3-BeyondThe3F/View/MusicPlayView.swift
@@ -13,7 +13,7 @@ struct MusicPlayView: View {
     
     @ObservedObject private var musicPlayer = MusicPlayer.shared
     @State private var progressRate: Double = 0.0
-    @State private var showCurrentPlayList: Bool = false
+    @State var showCurrentPlayList: Bool = false
     
     var body: some View {
         ZStack {
@@ -107,8 +107,7 @@ struct CurrentPlayListView: View {
     var body: some View {
         ScrollView {
             VStack(spacing: 0) {
-                Spacer()
-                    .frame(height: 16)
+                Spacer().frame(height: 16)
                 
                 HStack {
                     Text("현재 재생 목록")
@@ -124,7 +123,7 @@ struct CurrentPlayListView: View {
                 } else {
                     ForEach(0 ..< musicPlayer.playlist.count, id: \.self) { index in
                         Button {
-//                            musicPlayer.playSong(musicItem)     // 탭하면 해당 노래를 재생
+                            MusicPlayer.shared.playMusicInPlaylist(musicPlayer.playlist[index].musicId ?? "")
                         } label: {
                             HStack{
                                 if let url = imageUrl {
@@ -145,8 +144,9 @@ struct CurrentPlayListView: View {
                                         .frame(width: 60, height: 60)
                                         .cornerRadius(8)
                                 }
-                                Spacer()
-                                    .frame(width: 16)
+                                
+                                Spacer().frame(width: 16)
+                                
                                 VStack(alignment: .leading) {
                                     Text("\(musicPlayer.playlist[index].songName ?? "")")
                                         .body1(color: .white)
@@ -160,7 +160,9 @@ struct CurrentPlayListView: View {
                                         .lineLimit(1)
                                 }
                                 .frame(maxWidth: .infinity, alignment: .leading)
+                                
                                 Spacer()
+                                
                                 Button {
                                     
                                 } label: {
@@ -208,8 +210,9 @@ struct ControlPanelView: View {
                                 .headline(color: .white)
                                 .truncationMode(.tail)
                                 .lineLimit(1)
-                            Spacer()
-                                .frame(height: 8)
+                            
+                            Spacer().frame(height: 8)
+                            
                             Text("\(currentMusicItem.artistName ?? "")")
                                 .body1(color: .gray300)
                                 .truncationMode(.tail)
@@ -233,8 +236,7 @@ struct ControlPanelView: View {
                         SFImageComponentView(symbolName: .list, color: .white, width: 28, height: 28)
                     }
                 }
-                Spacer()
-                    .frame(height: 32)
+                Spacer().frame(height: 32)
                 
                 ControlButtonsView(progressRate: $progressRate)
             }


### PR DESCRIPTION
# PR 요약

작업한 브랜치
- feature/ #146 

# 작업한 내용
- 재생뷰에서 노래제목과 아티스트이름 좌측정렬
- 재생뷰에서 컨트롤 버튼들 위치 너무 아래에 있음 (조절 필요)
- 재생뷰에서 현재재생목록에 노래제목과 아티스트이름 정렬 수정 필요 (가운데로 뜸)
- 재생뷰에서 현재재생목록에 중복된 노래 처리 > 현재 재생 중인 순서의 노래를 백그라운드 컬러 활성화 (ForEach문 count로 변경)
- 재생뷰에서 현재재생목록 리스트 탭하면 해당 노래 재생
- 재생 컴포넌트뷰에서 리스트 아이콘 버튼 탭하면 재생뷰에서 리스트뷰가 활성화되도록 수정
- 재생 컴포넌트뷰에서 노래제목과 아티스트이름 좌측정렬


# 참고 사항
-

# 관련 이슈
- resolved : #146 
