### PR TITLE
MusicItemDataModel 의 saveMusicItem 메서드를 수정함으로써, 편집 기능 오류 해결

### DIFF
--- a/MC3-BeyondThe3F/MC3-BeyondThe3F/Model/MusicItemDataModel.swift
+++ b/MC3-BeyondThe3F/MC3-BeyondThe3F/Model/MusicItemDataModel.swift
@@ -45,9 +45,28 @@ class MusicItemDataModel {
             fatalError("Unresolved error \(nsError), \(nsError.userInfo)")
         }
     }
+    
+    func deleteMusicItemWith(uuid: UUID) {
+        let fetchRequest: NSFetchRequest<MusicItem> = MusicItem.fetchRequest()
+        fetchRequest.predicate = NSPredicate(format: "uuid == %@", uuid as CVarArg)
+
+        do {
+            let items = try persistentContainer.viewContext.fetch(fetchRequest)
+            for item in items {
+                persistentContainer.viewContext.delete(item)
+            }
+            try persistentContainer.viewContext.save()
+        } catch {
+            let nsError = error as NSError
+            fatalError("Unresolved error \(nsError), \(nsError.userInfo)")
+        }
+    }
+
 
     func saveMusicItem(musicItemVO:MusicItemVO) {
-        self.deleteMusicItemWith(musicId: musicItemVO.musicId, locationInfo: musicItemVO.locationInfo)
+        if let uuid = musicItemVO.id{
+            self.deleteMusicItemWith(uuid: uuid)
+        }
         let newItem = MusicItem(context: persistentContainer.viewContext)
 
         newItem.musicId = musicItemVO.musicId
@@ -58,7 +77,8 @@ class MusicItemDataModel {
         newItem.generatedDate = musicItemVO.generatedDate
         newItem.songName = musicItemVO.songName
         newItem.artistName = musicItemVO.artistName
-    
+        newItem.uuid = UUID()
+        
         do {
             try persistentContainer.viewContext.save()
         } catch {
@@ -66,7 +86,6 @@ class MusicItemDataModel {
             fatalError("Unresolved error \(nsError), \(nsError.userInfo)")
         }
     }
-    
     func getURL(_ musicId: String) async -> URL? {
         do {
             var searchRequest = MusicCatalogResourceRequest<Song>(matching: \.id, equalTo: MusicItemID(musicId))
@@ -94,3 +113,4 @@ class MusicItemDataModel {
         }
     }
 }
+

--- a/MC3-BeyondThe3F/MC3-BeyondThe3F/Model/MusicItemVO.swift
+++ b/MC3-BeyondThe3F/MC3-BeyondThe3F/Model/MusicItemVO.swift
@@ -9,7 +9,7 @@ import Foundation
 import MapKit
 
 struct MusicItemVO: Identifiable, Hashable {
-    var id = UUID()
+    var id:UUID?
     var musicId: String
     var latitude: Double
     var longitude: Double

--- a/MC3-BeyondThe3F/MC3-BeyondThe3F/Store/MC3_BeyondThe3F.xcdatamodeld/MC3_BeyondThe3F.xcdatamodel/contents
+++ b/MC3-BeyondThe3F/MC3-BeyondThe3F/Store/MC3_BeyondThe3F.xcdatamodeld/MC3_BeyondThe3F.xcdatamodel/contents
@@ -17,5 +17,6 @@
         <attribute name="musicId" attributeType="String" defaultValueString=""/>
         <attribute name="savedImage" optional="YES" attributeType="String"/>
         <attribute name="songName" attributeType="String" defaultValueString=""/>
+        <attribute name="uuid" optional="YES" attributeType="UUID" usesScalarValueType="NO"/>
     </entity>
 </model>

--- a/MC3-BeyondThe3F/MC3-BeyondThe3F/View/MainTabView.swift
+++ b/MC3-BeyondThe3F/MC3-BeyondThe3F/View/MainTabView.swift
@@ -29,11 +29,9 @@ struct MainTabView: View {
                 showWelcomeSheet = true
             }
             Task{
-//                await insertDummy()
+                await insertDummy()
                 await AuthManger.requestMusicAuth()
-                print(MusicItemDataModel.shared.musicList.count)
                 try? await Task.sleep(nanoseconds: 5 * 1_000_000_000)
-
             }
         }
         .sheet(isPresented: $showWelcomeSheet, onDismiss: {

--- a/MC3-BeyondThe3F/MC3-BeyondThe3F/View/MapMusicInfoView.swift
+++ b/MC3-BeyondThe3F/MC3-BeyondThe3F/View/MapMusicInfoView.swift
@@ -113,7 +113,8 @@ struct MapMusicInfoView: View {
                 ScrollView {
                     LazyVStack{
                         ForEach(musicList) { musicItem in
-                            if let validMusicItem = musicItem, musicItem.songName != ""{
+                            let validMusicItem = musicItem
+                            if musicItem.songName != ""{
                                 MusicListRowView(
                                     imageName: validMusicItem.savedImage ?? "annotation0",
                                     songName: validMusicItem.songName ?? "",


### PR DESCRIPTION
# PR 요약

작업한 브랜치
- feature/ #161 

# 작업한 내용
- saveMusicItem 의 파라미터로 전달되는 musicItem의 id 프라퍼티가 
  1.nil 인 경우엔, 음악이 추가됨.
  2. nil이 아니라 uuid일 경우엔, 코어데이터에 해당 uuid로 저장되어 있는 musicItem 을 제거 후 음악이 추가됨. 즉, 음악이 편집되는 효과. 


# 참고 사항
-

# 관련 이슈
- resolved : #161 
