### PR TITLE
[setting] # 193 - app store 심사 위해 info.plist 파일 수정

### DIFF
--- a/MC3-BeyondThe3F/MC3-BeyondThe3F.xcodeproj/project.pbxproj
+++ b/MC3-BeyondThe3F/MC3-BeyondThe3F.xcodeproj/project.pbxproj
@@ -671,9 +671,9 @@
 				DEVELOPMENT_TEAM = 333J2S2AQK;
 				ENABLE_PREVIEWS = YES;
 				GENERATE_INFOPLIST_FILE = YES;
-				INFOPLIST_KEY_NSAppleMusicUsageDescription = "Apple Music 사용을 허용하시겠습니까?";
-				INFOPLIST_KEY_NSLocationAlwaysAndWhenInUseUsageDescription = "위치를 항상 허용하시겠습니까?";
-				INFOPLIST_KEY_NSLocationWhenInUseUsageDescription = "위치를 언제 허용하시겠습니까?";
+				INFOPLIST_KEY_NSAppleMusicUsageDescription = "TuneSpot은 AppleMusic을 사용해서 음악을 재생할 수 있습니다. 재생기능을 사용하시려면 Apple Music 권한을 허용해주세요.";
+				INFOPLIST_KEY_NSLocationAlwaysAndWhenInUseUsageDescription = "TuneSpot은 지도에서 사용자의 현재 위치로 이동할 수 있는 기능을 제공하고 있습니다. 해당 기능을 사용하시려면 위치 권한을 허용해주세요.";
+				INFOPLIST_KEY_NSLocationWhenInUseUsageDescription = "TuneSpot은 지도에서 사용자의 현재 위치로 이동할 수 있는 기능을 제공하고 있습니다. 해당 기능을 사용하시려면 위치 권한을 허용해주세요.";
 				INFOPLIST_KEY_NSMicrophoneUsageDescription = "녹음 기능을 허용하시겠습니까?";
 				INFOPLIST_KEY_UIApplicationSceneManifest_Generation = YES;
 				INFOPLIST_KEY_UIApplicationSupportsIndirectInputEvents = YES;
@@ -707,9 +707,9 @@
 				DEVELOPMENT_TEAM = 333J2S2AQK;
 				ENABLE_PREVIEWS = YES;
 				GENERATE_INFOPLIST_FILE = YES;
-				INFOPLIST_KEY_NSAppleMusicUsageDescription = "Apple Music 사용을 허용하시겠습니까?";
-				INFOPLIST_KEY_NSLocationAlwaysAndWhenInUseUsageDescription = "위치를 항상 허용하시겠습니까?";
-				INFOPLIST_KEY_NSLocationWhenInUseUsageDescription = "위치를 언제 허용하시겠습니까?";
+				INFOPLIST_KEY_NSAppleMusicUsageDescription = "TuneSpot은 AppleMusic을 사용해서 음악을 재생할 수 있습니다. 재생기능을 사용하시려면 Apple Music 권한을 허용해주세요.";
+				INFOPLIST_KEY_NSLocationAlwaysAndWhenInUseUsageDescription = "TuneSpot은 지도에서 사용자의 현재 위치로 이동할 수 있는 기능을 제공하고 있습니다. 해당 기능을 사용하시려면 위치 권한을 허용해주세요.";
+				INFOPLIST_KEY_NSLocationWhenInUseUsageDescription = "TuneSpot은 지도에서 사용자의 현재 위치로 이동할 수 있는 기능을 제공하고 있습니다. 해당 기능을 사용하시려면 위치 권한을 허용해주세요.";
 				INFOPLIST_KEY_NSMicrophoneUsageDescription = "녹음 기능을 허용하시겠습니까?";
 				INFOPLIST_KEY_UIApplicationSceneManifest_Generation = YES;
 				INFOPLIST_KEY_UIApplicationSupportsIndirectInputEvents = YES;


### PR DESCRIPTION
# PR 요약

작업한 브랜치
- feature/ #193

# 작업한 내용
- AppStore에 TuneSpot 심사를 올린 결과 아래와 같은 피드백을 받았다. 위치와 Apple Music 권한을 요청하는 부분에서 이유에 대한 설명이 부족한 것이 원인이 되어 info.plist 파일을 수정하였다. 


Guideline 5.1.1 - Legal - Privacy - Data Collection and Storage

We noticed that your app requests the user’s consent to access the location and Apple Music library, but doesn’t sufficiently explain the use of the location and Apple Music library in the purpose string.

To help users make informed decisions about how their data is used, permission request alerts need to explain and include an example of how your app will use the requested information.

Next Steps

Please revise the purpose string in your app’s Info.plist file for the location and Apple Music library to explain why your app needs access and include an example of how the user's data will be used.

You can modify your app's Info.plist file using the property list editor in Xcode.

Resources

- Watch a video from App Store Review with [tips for writing clear purpose strings](https://developer.apple.com/go/?id=ar-tips-2).
- See examples of [helpful, informative purpose strings](https://developer.apple.com/design/human-interface-guidelines/patterns/accessing-private-data). 
- Review a list of [relevant property list keys](https://developer.apple.com/library/archive/documentation/General/Reference/InfoPlistKeyReference/Articles/CocoaKeys.html#//apple_ref/doc/uid/TP40009251-SW18).
Please see attached screenshots for details.



# 참고 사항
-

# 관련 이슈
- resolved : #이슈번호
